### PR TITLE
Make subscriptions recoverable. (use acts_as_paranoid)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,3 +101,5 @@ group :production do
   gem 'redis-rails'
   gem 'lograge'
 end
+
+gem 'paranoia', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,8 @@ GEM
     paperclip-av-transcoder (0.6.4)
       av (~> 0.9.0)
       paperclip (>= 2.5.2)
+    paranoia (2.3.0)
+      activerecord (>= 4.0, < 5.1)
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.20.0)
@@ -508,6 +510,7 @@ DEPENDENCIES
   ox
   paperclip (~> 5.1)
   paperclip-av-transcoder
+  paranoia (~> 2.2)
   pg
   pghero
   pkg-config

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Subscription < ApplicationRecord
+  acts_as_paranoid
+
   MIN_EXPIRATION = 3600 * 24 * 7
   MAX_EXPIRATION = 3600 * 24 * 30
 

--- a/db/migrate/20170418062843_add_deleted_at_to_subscriptions.rb
+++ b/db/migrate/20170418062843_add_deleted_at_to_subscriptions.rb
@@ -1,0 +1,7 @@
+class AddDeletedAtToSubscriptions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :subscriptions, :deleted_at, :datetime
+    add_index :subscriptions, [:callback_url, :account_id, :deleted_at], unique: true, name: 'index_subscriptions_on_callback_and_account'
+    remove_index :subscriptions, [:callback_url, :account_id]
+  end
+end


### PR DESCRIPTION
メンテナンスなどの影響によってPUSHの送信先サーバから 3xx, 4xx のレスポンスが返ってきた場合、
subscriptionsがdeleteされてしまい復旧する方法が7日間待つ以外になくなる問題の解決のため、
subscriptionsが論理削除されるように変更する。