### PR TITLE
Avoid duplicate hostname without s3

### DIFF
--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -12,6 +12,11 @@ module RoutingHelper
   end
 
   def full_asset_url(source)
-    Rails.configuration.x.use_s3 ? source : File.join(root_url, ActionController::Base.helpers.asset_url(source))
+    if Rails.configuration.x.use_s3
+	  source
+	else
+	  asset_url = ActionController::Base.helpers.asset_url(source)
+	  asset_url =~ /^http/ ? asset_url : File.join(root_url, asset_url)
+	end
   end
 end


### PR DESCRIPTION
Without S3, customizing paperclip hostname results duplicate hostname.
i.e. https://md.ggtea.org/https://store.ggtea.org/ ～。
This fix avoid this.